### PR TITLE
Laravel 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Laravel 5, 6 and 7 integration for Understand.io
+## Laravel 5, 6, 7 and 8 integration for Understand.io
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/understand/understand-laravel5.svg?style=flat-square)](https://packagist.org/packages/understand/understand-laravel5)
 [![Quality Score](https://img.shields.io/scrutinizer/g/understand/understand-laravel5.svg?style=flat-square)](https://scrutinizer-ci.com/g/understand/understand-laravel5)

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "require": {
         "php": ">=5.5.0",
         "ext-curl": "*",
-        "illuminate/support": "~5.0|~6.0|~7.0"
+        "illuminate/support": "~5.0|~6.0|~7.0|~8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0",
-        "orchestra/testbench": "^3.5",
+        "phpunit/phpunit": "~9.0",
+        "orchestra/testbench": "^6.2",
         "mockery/mockery": "^1.2"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     },
     "extra": {
         "component": "package",
-        "frameworks": ["Laravel 5", "Laravel 6", "Laravel 7"],
+        "frameworks": ["Laravel 5", "Laravel 6", "Laravel 7", "Laravel 8"],
         "branch-alias": {
 			"dev-master": "2.0-dev"
 		},

--- a/tests/ExceptionEncoderTest.php
+++ b/tests/ExceptionEncoderTest.php
@@ -101,7 +101,7 @@ class ExceptionEncoderTest extends TestCase
         $encoder = new Understand\UnderstandLaravel5\ExceptionEncoder();
         $stackTraceArray = $encoder->stackTraceToArray($exception->getTrace());
 
-        if (Str::startsWith(phpversion(), ['7.2', '7.3']))
+        if (Str::startsWith(phpversion(), ['7.2', '7.3', '7.4']))
         {
             $this->assertSame('__PHP_Incomplete_Class', $stackTraceArray[$index]['args'][0]);
         }


### PR DESCRIPTION
I'm submitting this light PR as I'd like to have Understand work with our Laravel 8 projects.

Updated composer.json to include Laravel 8 support.
Updated tests to handle PHP7.4 environment for testing.
Updated README.

Cheers - Paul